### PR TITLE
Fixed issue with array arguments

### DIFF
--- a/lib/object_perform_later.rb
+++ b/lib/object_perform_later.rb
@@ -1,13 +1,13 @@
 module ObjectPerformLater
   def perform_later(queue, method, *args)
-    return self.send(method, *args) unless PerformLater.config.enabled?
+    return args.size == 1 ? send(method, args.first) : send(method, args) unless PerformLater.config.enabled?
 
     worker = PerformLater::Workers::Objects::Worker
     perform_later_enqueue(worker, queue, method, args)
   end
 
   def perform_later!(queue, method, *args)
-    return self.send(method, *args) unless PerformLater.config.enabled?
+    return args.size == 1 ? send(method, args.first) : send(method, args) unless PerformLater.config.enabled?
 
     return "EXISTS!" if loner_exists(method, args)
 
@@ -24,9 +24,11 @@ module ObjectPerformLater
       return false
     end
 
-    def perform_later_enqueue(worker, queue, method, *args)
+    def perform_later_enqueue(worker, queue, method, args)
       args = PerformLater::ArgsParser.args_to_resque(args)
-      Resque::Job.create(queue, worker, self.name, method, args)
+      argument = args.size == 1 ? args.first : args
+      
+      Resque::Job.create(queue, worker, self.name, method, argument)
     end
 end
 

--- a/lib/perform_later/args_parser.rb
+++ b/lib/perform_later/args_parser.rb
@@ -7,24 +7,16 @@ module PerformLater
     AR_STRING_FORMAT    = /^AR\:([A-Z][\w\:]+)\:(\d+)$/
     YAML_STRING_FORMAT  = /\A---/
 
-    def self.args_to_resque(*args)
-      args = args.flatten.map { |o|
-        case o
-          when ActiveRecord::Base
-            "AR:#{o.class.name}:#{o.id}"
-          when Class, Module
-            "CLASS:#{o.name}"
-          when Hash
-            o.to_yaml
-          else
-            o
-        end
-      } if args
+    def self.args_to_resque(args)
+      return nil unless args
+      return arg_to_resque(args) unless args.is_a?(Array)
+      return args.map { |o| arg_to_resque o }
     end
     
     def self.args_from_resque(args)
-      args = args.flatten.map { |o|
+      args = args.map { |o|
         if o
+          o = args_from_resque(o) if o.is_a?(Array)
           case o
           when CLASS_STRING_FORMAT  then $1.constantize
           when AR_STRING_FORMAT     then $1.constantize.find_by_id($2)
@@ -33,6 +25,21 @@ module PerformLater
           end
         end
       } if args      
+    end
+
+  private
+
+    def self.arg_to_resque(arg)
+      case arg
+      when ActiveRecord::Base
+        "AR:#{arg.class.name}:#{arg.id}"
+      when Class, Module
+        "CLASS:#{arg.name}"
+      when Hash
+        arg.to_yaml
+      else
+        arg
+      end
     end
   end
 end

--- a/lib/perform_later/workers/objects/worker.rb
+++ b/lib/perform_later/workers/objects/worker.rb
@@ -3,10 +3,11 @@ module PerformLater
     module Objects
       class Worker
         def self.perform(klass_name, method, *args)
-          args = PerformLater::ArgsParser.args_from_resque(args)
+          arguments = PerformLater::ArgsParser.args_from_resque(args)
 
-          if args.length > 0
-            klass_name.constantize.send(method, *args)
+          if arguments.any?
+            argument =  arguments.size == 1 ? arguments.first : arguments
+            klass_name.constantize.send(method, argument)
           else
             klass_name.constantize.send(method)
           end

--- a/spec/lib/object_perform_later_spec.rb
+++ b/spec/lib/object_perform_later_spec.rb
@@ -53,7 +53,7 @@ describe ObjectPerformLater do
   end
 
   describe "When Enabled" do
-    it "should pass the correct valur(array)" do
+    it "should pass the correct value (array)" do
       PerformLater.config.stub!(:enabled?).and_return(true)
       Resque::Job.should_receive(:create).with(:generic, PerformLater::Workers::Objects::Worker, "DummyClass", :do_something_with_array, [1,2,3,4,5])
       DummyClass.perform_later(:generic, :do_something_with_array, [1,2,3,4,5])
@@ -64,6 +64,7 @@ describe ObjectPerformLater do
     before(:each) do
       PerformLater.config.stub!(:enabled?).and_return(false)
     end
+    
     it "should pass the correct value (String)" do
       DummyClass.perform_later(:generic, :do_something_with_string, "Avi Tzurel").should == "Avi Tzurel"
     end

--- a/spec/lib/perform_later/args_parser_spec.rb
+++ b/spec/lib/perform_later/args_parser_spec.rb
@@ -35,8 +35,7 @@ describe PerformLater::ArgsParser do
     it "should convert the AR object to the proper string" do
       user_id = user.id
 
-      subject.args_to_resque(user).length.should == 1
-      subject.args_to_resque(user)[0].should == "AR:User:#{user_id}"
+      subject.args_to_resque(user).should == "AR:User:#{user_id}"
     end
 
     it "should convert a hash into YAML string so that Resque will be able to JSON convert it" do
@@ -46,17 +45,17 @@ describe PerformLater::ArgsParser do
 
     it "should be able to load a yaml from the string and translate it into the same hash again" do
       hash = { name: "something", other: "something else" }
-      yaml = subject.args_to_resque(hash)[0]
+      yaml = subject.args_to_resque(hash)
 
       loaded_yaml = YAML.load(yaml)
-      
+
       loaded_yaml[:name].should == "something"
       loaded_yaml[:other].should == "something else"
     end
 
     it "should convert a class to the proper string representation" do
       klass = User
-      subject.args_to_resque(klass)[0].should == "CLASS:User"
+      subject.args_to_resque(klass).should == "CLASS:User"
     end
   end
 

--- a/spec/lib/perform_later/workers/objects/worker_spec.rb
+++ b/spec/lib/perform_later/workers/objects/worker_spec.rb
@@ -9,10 +9,9 @@ class DummyClass
     true
   end
 
-  def self.do_something_with_user(user)
-    user
+  def self.identity_function(data)
+    data
   end
-
 end
 
 describe PerformLater::Workers::Objects::Worker do
@@ -34,12 +33,18 @@ describe PerformLater::Workers::Objects::Worker do
   it "should pass a single argument (user)" do
     user = User.create
     args = PerformLater::ArgsParser.args_to_resque(user)
-    subject.perform("DummyClass", :do_something_with_user, args).should == user
+    subject.perform("DummyClass", :identity_function, args).should == user
   end
 
   it "should pass an array with one entry" do
     users = [User.create]
     args = PerformLater::ArgsParser.args_to_resque(users)
-    subject.perform("DummyClass", :do_something_with_user, args).should == users
+    subject.perform("DummyClass", :identity_function, args).should == users
+  end
+
+  it "should pass multi dimension arrays" do
+    data = [1, 2, User.create, ["a", "b", "c"]]
+    args = PerformLater::ArgsParser.args_to_resque(data)
+    subject.perform("DummyClass", :identity_function, args).should == data
   end
 end

--- a/spec/lib/perform_later/workers/objects/worker_spec.rb
+++ b/spec/lib/perform_later/workers/objects/worker_spec.rb
@@ -19,8 +19,6 @@ describe PerformLater::Workers::Objects::Worker do
   subject { PerformLater::Workers::Objects::Worker }
 
   it "should pass an array of hashes into the method" do
-    pending("This is a known issue with the gem")
-    
     arr = [
       { foo: "bar" },
       { bar: "foo" }
@@ -33,9 +31,15 @@ describe PerformLater::Workers::Objects::Worker do
     subject.perform("DummyClass", :do_something_without_args).should == true
   end
 
-  it "should pasa a single argument (user)" do
+  it "should pass a single argument (user)" do
     user = User.create
     args = PerformLater::ArgsParser.args_to_resque(user)
     subject.perform("DummyClass", :do_something_with_user, args).should == user
+  end
+
+  it "should pass an array with one entry" do
+    users = [User.create]
+    args = PerformLater::ArgsParser.args_to_resque(users)
+    subject.perform("DummyClass", :do_something_with_user, args).should == users
   end
 end


### PR DESCRIPTION
Extra splats were causing arrays to be wrapped inside another array causing other problems when passing array arguments around. Fixed that case.
An important gotcha is that when the *args array has a single element, that means the original method call consisted of a single entry as well so we should only send the first one.
