### PR TITLE
Delay feature - implemented for object_perform_later

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ end
 	  end
 	  later :lonely_long_running_method, :loner => true, queue: :some_queue_name
 
-    def delayed_long_running_method
-      # Your code here
-    end
-    later :delayed_long_running_method, :delay => 30, queue: :some_queue_name
+	  def delayed_long_running_method
+	    # Your code here
+	  end
+	  later :delayed_long_running_method, :delay => 30, queue: :some_queue_name
 	end
 	
 ```
@@ -75,7 +75,7 @@ end
 	u.long_running_method # Method will be queued into the :generic queue
 	u.long_running_method_2 # Method will be queued into :some_queue_name queue
 	u.lonely_long_running_method # Method will be queued into the :some_queue_name queue, only a single instance of this method can exist in the queue.
-  u.delayed_long_running_method # Method will be queued into :some_queue_name queue only after 30 seconds have passed.
+        u.delayed_long_running_method # Method will be queued into :some_queue_name queue only after 30 seconds have passed.
 ```
 
 You can of course choose to run the method off the queue, just prepend `now_` to the method name and it will be executed in sync.

--- a/README.md
+++ b/README.md
@@ -112,8 +112,6 @@ If you want the method to be a loner (only a single instance in the queue), you 
 	SomeClass.perform_later!(:queue_name, :some_more_heavy_lifting, user_id)
 ```
 
-```
-
 If you want you want to call a method after a delay, use the perform_later_in method.
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -112,6 +112,16 @@ If you want the method to be a loner (only a single instance in the queue), you 
 	SomeClass.perform_later!(:queue_name, :some_more_heavy_lifting, user_id)
 ```
 
+```
+
+If you want you want to call a method after a delay, use the perform_later_in method.
+
+```ruby
+  SomeClass.perform_later_in(delay_in_seconds, :queue_name, some_heavy_lifting, user_id)
+```
+
+```
+
 ## The params parser
 `perform_later` has a special class called `ArgsParser`, this class is in charge of *translating* the args you are passing into params that can actually be serialized to JSON cleanly.
 

--- a/README.md
+++ b/README.md
@@ -115,9 +115,7 @@ If you want the method to be a loner (only a single instance in the queue), you 
 If you want you want to call a method after a delay, use the perform_later_in method.
 
 ```ruby
-  SomeClass.perform_later_in(delay_in_seconds, :queue_name, some_heavy_lifting, user_id)
-```
-
+        SomeClass.perform_later_in(delay_in_seconds, :queue_name, some_heavy_lifting, user_id)
 ```
 
 ## The params parser

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ end
 	u.long_running_method # Method will be queued into the :generic queue
 	u.long_running_method_2 # Method will be queued into :some_queue_name queue
 	u.lonely_long_running_method # Method will be queued into the :some_queue_name queue, only a single instance of this method can exist in the queue.
-        u.delayed_long_running_method # Method will be queued into :some_queue_name queue only after 30 seconds have passed.
+	u.delayed_long_running_method # Method will be queued into :some_queue_name queue only after 30 seconds have passed.
 ```
 
 You can of course choose to run the method off the queue, just prepend `now_` to the method name and it will be executed in sync.
@@ -112,10 +112,10 @@ If you want the method to be a loner (only a single instance in the queue), you 
 	SomeClass.perform_later!(:queue_name, :some_more_heavy_lifting, user_id)
 ```
 
-If you want you want to call a method after a delay, use the perform_later_in method.
+If you want you want to call a method after a delay, use the `perform_later_in` method.
 
 ```ruby
-        SomeClass.perform_later_in(delay_in_seconds, :queue_name, some_heavy_lifting, user_id)
+	SomeClass.perform_later_in(delay_in_seconds, :queue_name, some_heavy_lifting, user_id)
 ```
 
 ## The params parser

--- a/lib/object_perform_later.rb
+++ b/lib/object_perform_later.rb
@@ -1,19 +1,38 @@
 module ObjectPerformLater
   def perform_later(queue, method, *args)
-    return perform_now(method, args) unless PerformLater.config.enabled?
+    return perform_now(method, args) if plugin_disabled?
 
     worker = PerformLater::Workers::Objects::Worker
-    perform_later_enqueue(worker, queue, method, args)
+    job    = PerformLater::JobCreator.new({queue: queue, worker: worker, klass_name: self.name, method: method}, *args)
+    perform_later_enqueue(job)
   end
 
   def perform_later!(queue, method, *args)
-    return perform_now(method, args) unless PerformLater.config.enabled?
+    return perform_now(method, args) if plugin_disabled?
 
     return "EXISTS!" if loner_exists(method, args)
 
     worker = PerformLater::Workers::Objects::LoneWorker
-    perform_later_enqueue(worker, queue, method, args)
+    job    = PerformLater::JobCreator.new({queue: queue, worker: worker, klass_name: self.name, method: method}, *args)
+    perform_later_enqueue(job)
   end
+
+  def perform_later_in(delay, queue, method, *args)
+    return perform_now(method, args) if plugin_disabled?
+
+    worker  = PerformLater::Workers::ActiveRecord::Worker
+    job     = PerformLater::JobCreator.new({queue: queue, worker: worker, klass_name: self.name, method: method}, *args) 
+    perform_later_enqueue(job, delay)
+  end
+  
+  def perform_later_in!(delay, queue, method, *args)
+    return  perform_now(method, args) if plugin_disabled?
+
+    worker  = PerformLater::Workers::ActiveRecord::LoneWorker
+    job     = PerformLater::JobCreator.new({queue: queue, worker: worker, klass_name: self.name, method: method}, *args) 
+    perform_later_enqueue(job, delay)
+  end
+
 
   private 
     def loner_exists(method, *args)
@@ -24,14 +43,19 @@ module ObjectPerformLater
       return false
     end
 
-    def perform_later_enqueue(worker, queue, method, args)
-      args = PerformLater::ArgsParser.args_to_resque(args)
-      args.size == 1 ? Resque::Job.create(queue, worker, self.name, method, args.first) : Resque::Job.create(queue, worker, self.name, method, *args)
+    def perform_later_enqueue(job,delay=nil)
+      job.args = PerformLater::ArgsParser.args_to_resque(job.args)
+      job.enqueue(delay)
     end
 
     def perform_now(method, args)
       args.size == 1 ? send(method, args.first) : send(method, *args)
     end
+
+    def plugin_disabled?
+      !PerformLater.config.enabled?
+    end
+
 end
 
 Object.send(:include, ObjectPerformLater)

--- a/lib/perform_later/job_creator.rb
+++ b/lib/perform_later/job_creator.rb
@@ -17,7 +17,7 @@ module PerformLater
     end
 
     def enqueue(delay=nil)
-      return Resque.enqueue_in_with_queue(queue, delay, worker, klass_name, id, method, args) if delay 
+      return Resque.enqueue_in_with_queue(queue, delay, worker, klass_name, id, method, *args) if delay 
       Resque::Job.create(queue, worker, klass_name, id, method, *args)
     end
   end

--- a/lib/perform_later/job_creator.rb
+++ b/lib/perform_later/job_creator.rb
@@ -4,13 +4,14 @@ module PerformLater
     attr_reader :queue, :worker, :klass_name, :id, :method
     attr_accessor :args
 
-    def initialize(queue, worker, klass_name, id, method, *args)
-      @queue       = queue
-      @worker      = worker
-      @klass_name  = klass_name
-      @id          = id
-      @method      = method
-      @args        = args
+    def initialize(opts, *args)
+      defaults = {id: nil}
+      defaults.merge!(opts)
+
+      opts.each do |k,v|
+        instance_variable_set("@#{k}", v) unless v.nil?
+      end
+      @args = args
     end
 
     def enqueue(delay=nil)

--- a/lib/perform_later/job_creator.rb
+++ b/lib/perform_later/job_creator.rb
@@ -8,10 +8,12 @@ module PerformLater
       defaults = {id: nil}
       defaults.merge!(opts)
 
-      opts.each do |k,v|
-        instance_variable_set("@#{k}", v) unless v.nil?
-      end
-      @args = args
+      @queue       = opts[:queue]
+      @worker      = opts[:worker]
+      @klass_name  = opts[:klass_name]
+      @id          = opts[:id]
+      @method      = opts[:method]
+      @args        = args
     end
 
     def enqueue(delay=nil)

--- a/lib/resque/plugins/later/method.rb
+++ b/lib/resque/plugins/later/method.rb
@@ -20,7 +20,7 @@ module Resque::Plugins::Later::Method
           Resque.redis.set(digest, 'EXISTS')
         end
 
-        job = PerformLater::JobCreator.new(queue, klass, send(:class).name, send(:id), "now_#{method_name}", *args)
+        job = PerformLater::JobCreator.new({queue: queue, worker: klass, klass_name: send(:class).name, id: send(:id), method: "now_#{method_name}"}, *args)
         job.enqueue(delay)
       end
     end
@@ -31,7 +31,7 @@ module Resque::Plugins::Later::Method
     return perform_now(method, args) if plugin_disabled?
 
     worker  = PerformLater::Workers::ActiveRecord::Worker
-    job     = PerformLater::JobCreator.new(queue, worker, self.class.name, self.id, method, *args) 
+    job     = PerformLater::JobCreator.new({queue: queue, worker: worker, klass_name: self.class.name, id: self.id, method: method}, *args) 
     enqueue_in_resque_or_send(job)
   end
 
@@ -40,7 +40,7 @@ module Resque::Plugins::Later::Method
     return "AR EXISTS!" if loner_exists(method, args)
     
     worker  = PerformLater::Workers::ActiveRecord::LoneWorker
-    job     = PerformLater::JobCreator.new(queue, worker, self.class.name, self.id, method, *args) 
+    job     = PerformLater::JobCreator.new({queue: queue, worker: worker, klass_name: self.class.name, id: self.id, method: method}, *args) 
     enqueue_in_resque_or_send(job)
   end
 
@@ -48,7 +48,7 @@ module Resque::Plugins::Later::Method
     return perform_now(method, args) if plugin_disabled?
 
     worker  = PerformLater::Workers::ActiveRecord::Worker
-    job     = PerformLater::JobCreator.new(queue, worker, self.class.name, self.id, method, *args) 
+    job     = PerformLater::JobCreator.new({queue: queue, worker: worker, klass_name: self.class.name, id: self.id, method: method}, *args) 
     enqueue_in_resque_or_send(job, delay)
   end
   
@@ -56,7 +56,7 @@ module Resque::Plugins::Later::Method
     return  perform_now(method, args) if plugin_disabled?
 
     worker  = PerformLater::Workers::ActiveRecord::LoneWorker
-    job     = PerformLater::JobCreator.new(queue, worker, self.class.name, self.id, method, *args) 
+    job     = PerformLater::JobCreator.new({queue: queue, worker: worker, klass_name: self.class.name, id: self.id, method: method}, *args) 
     enqueue_in_resque_or_send(job, delay)
   end
 

--- a/spec/lib/object_perform_later_spec.rb
+++ b/spec/lib/object_perform_later_spec.rb
@@ -61,25 +61,25 @@ describe ObjectPerformLater do
 
     it "should pass no values" do
       PerformLater.config.stub!(:enabled?).and_return(true)
-      Resque::Job.should_receive(:create).with(:generic, PerformLater::Workers::Objects::Worker, "DummyClass", :do_something_with_array)
+      Resque::Job.should_receive(:create).with(:generic, PerformLater::Workers::Objects::Worker, "DummyClass", nil, :do_something_with_array)
       DummyClass.perform_later(:generic, :do_something_with_array)
     end
 
     it "should pass the correct value (array)" do
       PerformLater.config.stub!(:enabled?).and_return(true)
-      Resque::Job.should_receive(:create).with(:generic, PerformLater::Workers::Objects::Worker, "DummyClass", :do_something_with_array, [1,2,3,4,5])
+      Resque::Job.should_receive(:create).with(:generic, PerformLater::Workers::Objects::Worker, "DummyClass", nil, :do_something_with_array, [1,2,3,4,5])
       DummyClass.perform_later(:generic, :do_something_with_array, [1,2,3,4,5])
     end
 
     it "should pass multiple args" do
       PerformLater.config.stub!(:enabled?).and_return(true)
-      Resque::Job.should_receive(:create).with(:generic, PerformLater::Workers::Objects::Worker, "DummyClass", :do_something_with_multiple_args, 1, 2)
+      Resque::Job.should_receive(:create).with(:generic, PerformLater::Workers::Objects::Worker, "DummyClass", nil, :do_something_with_multiple_args, 1, 2)
       DummyClass.perform_later(:generic, :do_something_with_multiple_args, 1, 2)
     end
 
     it "should pass AR and hash" do
       PerformLater.config.stub!(:enabled?).and_return(true)
-      Resque::Job.should_receive(:create).with(:generic, PerformLater::Workers::Objects::Worker, "DummyClass", :do_something_with_multiple_args, "AR:User:#{user.id}", "---\n:a: 2\n")
+      Resque::Job.should_receive(:create).with(:generic, PerformLater::Workers::Objects::Worker, "DummyClass", nil, :do_something_with_multiple_args, "AR:User:#{user.id}", "---\n:a: 2\n")
       DummyClass.perform_later(:generic, :do_something_with_multiple_args, user, {a: 2})
     end
   end

--- a/spec/lib/perform_later/job_creator_spec.rb
+++ b/spec/lib/perform_later/job_creator_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe PerformLater::JobCreator do
   
-  let(:job)    {PerformLater::JobCreator.new("some_queue", "WorkerClass", "Klass_name", 2, :the_method)}
+  let(:job)    {PerformLater::JobCreator.new(queue: "some_queue", worker: "WorkerClass", klass_name: "Klass_name", id: 2, method: :the_method)}
   let(:delay)  {42}
 
   describe :enqueue do


### PR DESCRIPTION
- Added delay implementation to object_perform_later.
- Implemented job_creator in object_perform_later.
- Changed job_creator to receive args in hash form in order handle messages from AR objects - with id -  and normal object instances - without an id.
- README - fixed funny indentation caused by indenting with spaces instead of tabs.
- Added splat to args in job_creator.
